### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-
-
 <div align="center">
 <img src="assets/header-animation.svg" width="100%">
 
@@ -14,6 +12,9 @@
 <img alt="npm" src="https://img.shields.io/npm/dt/@sunwood-ai-labs/ideagram-mcp-server">
 </p>
 
+<a href="https://glama.ai/mcp/servers/xzcx34d305">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/xzcx34d305/badge" alt="Ideogram Server MCP server" />
+</a>
 
 Ideogram APIを使用して画像生成機能を提供するModel Context Protocol (MCP) サーバー
 


### PR DESCRIPTION
This PR adds a badge for the [Ideogram MCP Server](https://glama.ai/mcp/servers/xzcx34d305) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/xzcx34d305">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/xzcx34d305/badge" alt="Ideogram Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.