### PR TITLE
fix: npm version command to handle v-prefixed version tags

### DIFF
--- a/.github/workflows/npm-publish-release.yml
+++ b/.github/workflows/npm-publish-release.yml
@@ -29,8 +29,15 @@ jobs:
         id: get_version
         run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
 
+      - name: Remove 'v' prefix from version (if present)
+        id: clean_version
+        run: |
+          VERSION="${{ steps.get_version.outputs.VERSION }}"
+          CLEAN_VERSION="${VERSION#v}"
+          echo "CLEAN_VERSION=${CLEAN_VERSION}" >> $GITHUB_OUTPUT
+
       - name: Update version in package.json
-        run: npm version ${{ steps.get_version.outputs.VERSION }} --no-git-tag-version
+        run: npm version ${{ steps.clean_version.outputs.CLEAN_VERSION }} --no-git-tag-version
 
       - name: Build
         run: npm run build


### PR DESCRIPTION
## 問題点

GitHub Actionsのワークフローで、リリース時に発生する \Unknown command: "error"

To see a list of supported npm commands, run:
  npm help エラーを修正します。

## 原因

GitHub Releasesでは通常タグ名に \ プレフィックスがつきます（例: \）が、\{
  '@sunwood-ai-labs/ideagram-mcp-server': '0.2.0',
  npm: '10.8.2',
  node: '20.19.1',
  acorn: '8.14.0',
  ada: '2.9.2',
  ares: '1.34.5',
  brotli: '1.1.0',
  cjs_module_lexer: '1.4.1',
  cldr: '46.0',
  icu: '76.1',
  llhttp: '8.1.2',
  modules: '115',
  napi: '9',
  nghttp2: '1.61.0',
  nghttp3: '0.7.0',
  ngtcp2: '1.1.0',
  openssl: '3.0.15+quic',
  simdutf: '6.0.3',
  tz: '2025a',
  undici: '6.21.2',
  unicode: '16.0',
  uv: '1.46.0',
  uvwasi: '0.0.21',
  v8: '11.3.244.8-node.26',
  zlib: '1.3.0.1-motley-82a5fec'
} コマンドはセマンティックバージョンが \ なしで渡されることを期待します（例: \）。

## 修正内容

1. GitHubリリースタグから取得したバージョン文字列から \ プレフィックスを削除するステップを追加
2. \{
  '@sunwood-ai-labs/ideagram-mcp-server': '0.2.0',
  npm: '10.8.2',
  node: '20.19.1',
  acorn: '8.14.0',
  ada: '2.9.2',
  ares: '1.34.5',
  brotli: '1.1.0',
  cjs_module_lexer: '1.4.1',
  cldr: '46.0',
  icu: '76.1',
  llhttp: '8.1.2',
  modules: '115',
  napi: '9',
  nghttp2: '1.61.0',
  nghttp3: '0.7.0',
  ngtcp2: '1.1.0',
  openssl: '3.0.15+quic',
  simdutf: '6.0.3',
  tz: '2025a',
  undici: '6.21.2',
  unicode: '16.0',
  uv: '1.46.0',
  uvwasi: '0.0.21',
  v8: '11.3.244.8-node.26',
  zlib: '1.3.0.1-motley-82a5fec'
} コマンドには、このプレフィックスを削除したバージョン文字列を渡すように修正

これにより、GitHub Releasesのタグが \ 形式であっても、npmには \ として渡されるため、エラーが解消されます。